### PR TITLE
[WIP] Prepared conv1d layers for tfjs.

### DIFF
--- a/pytorch2keras/converter.py
+++ b/pytorch2keras/converter.py
@@ -204,11 +204,11 @@ def pytorch_to_keras(
             # Tensorflow needs a new graph for the converted model
             # to retain the same scopes for the operators.
             import tensorflow as tf
-            with tf.Graph().as_default():
-                K.set_session(tf.Session())
-                model_tf_ordering = keras.models.Model.from_config(config)
-                for dst, src in zip(model_tf_ordering.layers, src_weights):
-                    dst.set_weights(src)
+            tf.reset_default_graph()
+            K.set_session(tf.Session())
+            model_tf_ordering = keras.models.Model.from_config(config)
+            for dst, src in zip(model_tf_ordering.layers, src_weights):
+                dst.set_weights(src)
         else:
             model_tf_ordering = keras.models.Model.from_config(config)
             for dst, src in zip(model_tf_ordering.layers, src_weights):

--- a/pytorch2keras/converter.py
+++ b/pytorch2keras/converter.py
@@ -190,7 +190,7 @@ def pytorch_to_keras(
                 lc['data_format'] = 'channels_last'
 
             if 'axis' in lc:
-                lc['axis'] = 2
+                lc['axis'] = len(lc['batch_input_shape'])-1
 
         K.set_image_data_format('channels_last')
 

--- a/pytorch2keras/layers.py
+++ b/pytorch2keras/layers.py
@@ -318,7 +318,7 @@ def convert_dropout(params, w_name, scope_name, inputs, layers, weights):
     """
     print('Converting dropout ...')
 
-    tf_name = 'Dropout_{}.{}'.format(w_name, scope_name)
+    tf_name = 'Dropout_{}_{}'.format(w_name, scope_name)
     dropout = keras.layers.Dropout(rate=params['ratio'], name=tf_name)
     layers[scope_name] = dropout(layers[inputs[0]])
 
@@ -486,7 +486,7 @@ def convert_relu(params, w_name, scope_name, inputs, layers, weights):
     global relu_count
     print('Converting relu ...')
 
-    tf_name = 'Relu_%s.%i'%(w_name, relu_count)
+    tf_name = 'Relu_%s_%i'%(w_name, relu_count)
     relu_count += 1
 
     relu = keras.layers.Activation('relu', name=tf_name)
@@ -547,6 +547,25 @@ def convert_softmax(params, w_name, scope_name, inputs, layers, weights):
     print('Converting softmax ...')
 
     tf_name = w_name + str(random.random())
+    softmax = keras.layers.Activation('softmax', name=tf_name)
+    layers[scope_name] = softmax(layers[inputs[0]])
+
+
+def convert_logsoftmax(params, w_name, scope_name, inputs, layers, weights):
+    """
+    Convert log-softmax layer.
+
+   Args:
+        params: dictionary with layer parameters
+        w_name: name prefix in state_dict
+        scope_name: pytorch scope name
+        inputs: pytorch node inputs
+        layers: dictionary with keras tensors
+        weights: pytorch state_dict
+    """
+    print('Converting softmax ...')
+
+    tf_name = 'Softmax_'+w_name
     softmax = keras.layers.Activation('softmax', name=tf_name)
     layers[scope_name] = softmax(layers[inputs[0]])
 
@@ -825,6 +844,7 @@ AVAILABLE_CONVERTERS = {
     'onnx::LeakyRelu': convert_lrelu,
     'onnx::Sigmoid': convert_sigmoid,
     'onnx::Softmax': convert_softmax,
+    'onnx::LogSoftmax': convert_logsoftmax,
     'onnx::Tanh': convert_tanh,
     'onnx::Selu': convert_selu,
     'onnx::Transpose': convert_transpose,


### PR DESCRIPTION
I work towards adopting the module to allow for a seemless integration
with `tensoflow.js`.  My usecase targets Conv1d layers, which is why
changes to convert_conv are only partial.  There are two main changes:

* pytorch uses 'NCW' which needs to be converted to 'NWC' for
tensorflow.  However, we want to retain the cool names of our graph's
operators, which is why we need to create a temporary new one that will
hold the ops with changed order.

* PaddingLayers are not supported by tfjs as of now.  We therefore allow
for a 'valid' mode conv1d layer where the padding helper-layer is
omitted.  We also allow to provide the data-format in `params`.

* We need to avoid the long random-number names b/c these aren't
supported by tfjs.