### PR TITLE
Fixed Lambda Layer Related Errors

### DIFF
--- a/pytorch2keras/layers.py
+++ b/pytorch2keras/layers.py
@@ -643,7 +643,8 @@ def convert_sum(
     print('Converting Sum ...')
 
     def target_layer(x):
-        return keras.backend.sum(x)
+        import keras.backend as K
+        return K.sum(x)
 
     lambda_layer = keras.layers.Lambda(target_layer)
     layers[scope_name] = lambda_layer(layers[inputs[0]])
@@ -1002,10 +1003,11 @@ def convert_reduce_sum(params, w_name, scope_name, inputs, layers, weights, shor
     print('Converting reduce_sum ...')
 
     keepdims = params['keepdims'] > 0
-    axis = np.array(params['axes'])
+    axis = params['axes']
 
     def target_layer(x, keepdims=keepdims, axis=axis):
-        return keras.backend.sum(x, keepdims=keepdims, axis=axis)
+        import keras.backend as K
+        return K.sum(x, keepdims=keepdims, axis=axis)
 
     lambda_layer = keras.layers.Lambda(target_layer)
     layers[scope_name] = lambda_layer(layers[inputs[0]])
@@ -1026,12 +1028,15 @@ def convert_constant(params, w_name, scope_name, inputs, layers, weights, short_
     """
     print('Converting constant ...')
 
-    # def target_layer(x, params=params):
-    #     return keras.backend.constant(np.float32(params['value']))
+    params_list = params['value'].numpy().tolist()
 
-    # lambda_layer = keras.layers.Lambda(target_layer)
-    # layers[scope_name] = lambda_layer(layers[inputs[0]])
-    layers[scope_name] = np.float32(params['value'])
+    def target_layer(x):
+        import keras.backend as K
+        return K.constant(params_list)
+
+    lambda_layer = keras.layers.Lambda(target_layer)
+    layers[scope_name] = lambda_layer(layers['input0']) # Temporary fix for nonexistent input name created by converter.py
+    # layers[scope_name] = params['value']
 
 
 def convert_upsample(params, w_name, scope_name, inputs, layers, weights, short_names):


### PR DESCRIPTION
Details of changes are illustrated in #21. 

The only difference is that #21 refers to version 0.1.2 while in 0.1.4 converter.py will create input for each constant tensor (as they don't have real input), which leads to key error in `layers[inputs[0]]` and thus a temporary fix of using hard-coded name 'input0' is introduced.