### PR TITLE
fix: models reusing inputs from previous layers

### DIFF
--- a/pytorch2keras/converter.py
+++ b/pytorch2keras/converter.py
@@ -131,6 +131,7 @@ def pytorch_to_keras(
     outputs = []
 
     input_index = 0
+    model_inputs = dict()
     for node in nodes:
         node_inputs = list(node.inputs())
         node_input_names = []
@@ -139,8 +140,13 @@ def pytorch_to_keras(
                 node_input_names.append(get_node_id(node_input.node()))
 
         if len(node_input_names) == 0:
-            node_input_names.append('input{0}'.format(input_index))
-            input_index += 1
+            if node_inputs[0] in model_inputs:
+                node_input_names.append(model_inputs[node_inputs[0]])
+            else:
+                input_name = 'input{0}'.format(input_index)
+                node_input_names.append(input_name)
+                input_index += 1
+                model_inputs[node_inputs[0]] = input_name
 
         node_type = node.kind()
         # print(dir(node))


### PR DESCRIPTION
This fixes the case where the model input is used again in a deeper layer. E.g:

```
input0 --- L1 ---\
       \----------- L2 ---- ...
```

Currenly L2 will try to use 'input1', which doesn't exist.