### PR TITLE
Fix convert_elementwise_mul to support broadcasting

### DIFF
--- a/pytorch2keras/layers.py
+++ b/pytorch2keras/layers.py
@@ -738,9 +738,15 @@ def convert_elementwise_mul(
     else:
         tf_name = w_name + str(random.random())
 
-    mul = keras.layers.Multiply(name=tf_name)
-    print(model0, model1)
-    layers[scope_name] = mul([model0, model1])
+    def target_layer(x):
+        layer = tf.multiply(
+            x[0],
+            x[1]
+        )
+        return layer
+
+    lambda_layer = keras.layers.Lambda(target_layer, name=tf_name)
+    layers[scope_name] = lambda_layer([layers[inputs[0]], layers[inputs[1]]])
 
 
 def convert_elementwise_div(


### PR DESCRIPTION
This pull request changes ```convert_elementwise_mul``` to use ```tf.multiply()``` instead of ```keras.layers.Multiply()```, which supports broadcasting.
For example, when a PyTorch model contains a part that multiplies just a constant value to a matrix, ```keras.layers.Multiply()``` throws an error, while ```tf.multiply()``` does not.

The function ```convert_elementwise_div``` already uses the TensorFlow's function, so this pull request uses the same structure of that function.