### PR TITLE
Update conditions on pytorch versions

### DIFF
--- a/pytorch2keras/converter.py
+++ b/pytorch2keras/converter.py
@@ -38,7 +38,7 @@ def set_training(model, mode):
             model.train(old_mode)
 
 
-if version.parse('0.4.1') < version.parse(torch.__version__):
+if version.parse('1.0.0') <= version.parse(torch.__version__):
     from torch._C import ListType
 
     # ONNX can't handle constants that are lists of tensors, which can
@@ -59,7 +59,7 @@ if version.parse('0.4.1') < version.parse(torch.__version__):
                           .setType(ListType.ofTensors()))
                     node.output().replaceAllUsesWith(lc)
 
-if version.parse('0.4.0') >= version.parse(torch.__version__):
+if version.parse('1.0.0') > version.parse(torch.__version__):
     def _optimize_graph(graph, aten):
         # run dce first to eliminate dead parts of the graph that might have been
         # left behind by things like symbolic_override
@@ -79,7 +79,7 @@ if version.parse('0.4.0') >= version.parse(torch.__version__):
         return graph
 else:
     def _optimize_graph(graph, operator_export_type=OperatorExportTypes.RAW):
-        if version.parse('0.4.1') < version.parse(torch.__version__):
+        if version.parse('1.0.0') <= version.parse(torch.__version__):
             torch._C._jit_pass_remove_inplace_ops(graph)
             # we record now record some ops like ones/zeros
             # into a trace where we previously recorded constants


### PR DESCRIPTION
Update conditions to support pytorch sub-versions between 0.4.1 and 1.0.0

**Tested on Pytorch 0.4.1.post2 and 0.5.0a0. PLEASE CHECK THAT IT WORKS WITH 1.0.0 as I could not test it myself**