### PR TITLE
Explicit Tensorflow import in lambda layer

### DIFF
--- a/pytorch2keras/operation_layers.py
+++ b/pytorch2keras/operation_layers.py
@@ -140,6 +140,7 @@ def convert_clip(params, w_name, scope_name, inputs, layers, weights, names):
     print('Converting clip ...')
 
     def target_layer(x, vmin=params['min'], vmax=params['max']):
+        import tensorflow as tf
         return tf.clip_by_value(x, vmin, vmax)
 
     lambda_layer = keras.layers.Lambda(target_layer)


### PR DESCRIPTION
While converting a model that has this layer with `change_ordering = True`, I got a crash because `tf` was not defined. Apparently the lambda is executed quite literally without the scope context. To be perfectly honest I have no idea about the specifics there, but this change fixes the crash.