### PR TITLE
Use DepthwiseConv2D rather than SeparableConv2D with no-op pointwise conv

### DIFF
--- a/pytorch2keras/convolution_layers.py
+++ b/pytorch2keras/convolution_layers.py
@@ -112,6 +112,7 @@ def convert_conv(params, w_name, scope_name, inputs, layers, weights, names):
                 activation=None,
                 depth_multiplier=1,
                 weights = weights,
+                dilation_rate=params['dilations'][0],
                 bias_initializer='zeros', kernel_initializer='zeros'
             )
             layers[scope_name] = conv(layers[input_name])

--- a/pytorch2keras/convolution_layers.py
+++ b/pytorch2keras/convolution_layers.py
@@ -98,26 +98,21 @@ def convert_conv(params, w_name, scope_name, inputs, layers, weights, names):
                 biases = None
                 has_bias = False
 
-            # We are just doing depthwise conv, so make the pointwise a no-op
-            pointwise_wt = np.expand_dims(np.expand_dims(np.identity(out_channels), 0), 0)
             W = W.transpose(0, 1, 3, 2)
             if has_bias:
-                weights = [W, pointwise_wt, biases]
+                weights = [W, biases]
             else:
-                weights = [W, pointwise_wt]
+                weights = [W]
 
-            conv = keras.layers.SeparableConv2D(
-                filters=out_channels,
-                depth_multiplier=1,
+            conv = keras.layers.DepthwiseConv2D(
                 kernel_size=(height, width),
                 strides=(params['strides'][0], params['strides'][1]),
                 padding='valid',
-                weights=weights,
                 use_bias=has_bias,
                 activation=None,
-                dilation_rate=params['dilations'][0],
-                bias_initializer='zeros', kernel_initializer='zeros',
-                name=tf_name
+                depth_multiplier=1,
+                weights = weights,
+                bias_initializer='zeros', kernel_initializer='zeros'
             )
             layers[scope_name] = conv(layers[input_name])
 


### PR DESCRIPTION
I noticed that my converted frozen `.pb` was _much_ larger than a very similar model natively defined in Tensorflow. This turned out to be because of the pointwise convolution weights stored in the converted model - but these weights were all zero. I figured that instead of using a separable conv with a no-op pointwise conv, we can simply use a depthwise conv. I replaced it, and everything appears to be working as expected. `tests/layers/convolutions/conv2d.py` runs with a max error of `8.344650268554688e-07`.

There is one caveat, which is that for whatever reason the `dilation_rate` parameter of `keras.layers.DepthwiseConv2D` isn't explicitly documented. This seems to be a documentation error rather than it being an unsupported feature, because [it is most definitely used in the functional layer](https://github.com/keras-team/keras/blob/master/keras/layers/convolutional.py#L1842).

EDIT: Oh, and as a result, my `.pb` file went from 4.4mb to 1.3mb with the exact same output error (compared to the PyTorch model).