### PR TITLE
Converting clip with a min value of 0 as a ReLU

### DIFF
--- a/pytorch2keras/operation_layers.py
+++ b/pytorch2keras/operation_layers.py
@@ -139,9 +139,13 @@ def convert_clip(params, w_name, scope_name, inputs, layers, weights, names):
     """
     print('Converting clip ...')
 
-    def target_layer(x, vmin=params['min'], vmax=params['max']):
-        import tensorflow as tf
-        return tf.clip_by_value(x, vmin, vmax)
+    if params['min'] == 0:
+        print("using ReLU({0})".format(params['max']))
+        layer = keras.layers.ReLU(max_value=params['max'])
+    else:
+        def target_layer(x, vmin=params['min'], vmax=params['max']):
+            import tensorflow as tf
+            return tf.clip_by_value(x, vmin, vmax)
+        layer = keras.layers.Lambda(target_layer)
 
-    lambda_layer = keras.layers.Lambda(target_layer)
-    layers[scope_name] = lambda_layer(layers[inputs[0]])
+    layers[scope_name] = layer(layers[inputs[0]])


### PR DESCRIPTION
This is a minor optimization: in my TensorFlow graphs I can see that the `clip_by_value` lambda layer is converted as two layers (a clip with a maximum and a clip with a minimum). When the minimum value is of the clip is 0, the clip is equivalent to a [ReLU layer](https://keras.io/layers/advanced-activations/#relu) with the max argument set. The resulting output has just a single node in the final graph, if the max value is 6 it actually turns in to a `ReLU6` layer automatically. In my experience the clip nodes often come from `ReLU6` in the original graph, so this makes for the best conversion.