### PR TITLE
fix flatten issue in converted tensorflowjs model

### DIFF
--- a/pytorch2keras/reshape_layers.py
+++ b/pytorch2keras/reshape_layers.py
@@ -28,7 +28,14 @@ def convert_flatten(params, w_name, scope_name, inputs, layers, weights, names):
     else:
         tf_name = w_name + str(random.random())
 
-    reshape = keras.layers.Reshape([-1], name=tf_name)
+    flat_size = 1
+    for d in layers[inputs[0]].shape:
+        try:
+            flat_size = flat_size * int(d)
+        except TypeError:
+            pass
+
+    reshape = keras.layers.Reshape([flat_size], name=tf_name)
     layers[scope_name] = reshape(layers[inputs[0]])
 
 


### PR DESCRIPTION
explicitly set the size to match the input instead of using -1, so that tensorflowjs won't complain about shape mismatch [None, actual_size]